### PR TITLE
Add iMessage-style monitoring UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,12 @@ STUDIO_FLOW_SID=
 # required: false
 EXA_API_KEY=
 
-# description: An API key for OpenAI 
+# description: An API key for OpenAI
 # format: secret
 # required: false
 OPENAI_API_KEY=
+
+# description: Conversations Service SID used by the web UI
+# format: sid
+# required: true
+CONVERSATIONS_SERVICE_SID=

--- a/README.md
+++ b/README.md
@@ -193,3 +193,19 @@ This tool enables you to trigger functions in the web UI of your AI Assistant as
 ## License
 
 MIT
+
+## iMessage Style Monitoring UI
+
+This repository now includes a simple web interface for monitoring and managing
+your AI Assistant conversations in real time. The interface mimics the familiar
+iMessage layout and allows human agents to take over or resume automated
+responses at any time.
+
+To access the UI after deploying the Functions, open
+`https://<your-functions-domain>.twil.io/imessage/` in your browser. When
+prompted, enter an identity for the agent. The page lists all conversations from
+the configured Conversations Service and updates in real time.
+
+Each thread provides a **Disable AI** button. Toggling this puts the current
+conversation into human takeover mode. Press **Enable AI** to allow the
+assistant to reply again.

--- a/assets/imessage/app.js
+++ b/assets/imessage/app.js
@@ -1,0 +1,92 @@
+let client;
+let currentConversation;
+
+async function getToken(identity) {
+  const resp = await fetch(`/channels/conversations/token?identity=${encodeURIComponent(identity)}`);
+  const data = await resp.json();
+  return data.token;
+}
+
+function renderThread(conversation) {
+  const li = document.createElement('li');
+  li.textContent = conversation.friendlyName || conversation.sid;
+  li.onclick = () => openConversation(conversation);
+  li.id = conversation.sid;
+  document.getElementById('thread-list').appendChild(li);
+}
+
+async function loadConversations() {
+  const paginator = await client.getSubscribedConversations();
+  paginator.items.forEach(renderThread);
+}
+
+function addMessage(msg) {
+  const div = document.createElement('div');
+  div.className = 'message ' + (msg.author === client.identity ? 'outgoing' : 'incoming');
+  const bubble = document.createElement('div');
+  bubble.className = 'bubble';
+  bubble.textContent = msg.body;
+  div.appendChild(bubble);
+  document.getElementById('message-list').appendChild(div);
+  document.getElementById('message-list').scrollTop = document.getElementById('message-list').scrollHeight;
+}
+
+function clearMessages() {
+  document.getElementById('message-list').innerHTML = '';
+}
+
+async function openConversation(conversation) {
+  if (currentConversation) {
+    currentConversation.removeAllListeners();
+    document.getElementById(currentConversation.sid).classList.remove('active');
+  }
+  currentConversation = conversation;
+  document.getElementById(conversation.sid).classList.add('active');
+  document.getElementById('messages').classList.remove('hidden');
+  document.getElementById('contact').textContent = conversation.friendlyName || conversation.sid;
+  document.getElementById('message-input').value = '';
+  clearMessages();
+  const msgs = await conversation.getMessages();
+  msgs.items.forEach(addMessage);
+  const attributes = conversation.attributes || {};
+  updateToggleButton(attributes.assistantDisabled);
+  conversation.on('messageAdded', addMessage);
+  conversation.on('typingStarted', () => document.getElementById('typing').classList.remove('hidden'));
+  conversation.on('typingEnded', () => document.getElementById('typing').classList.add('hidden'));
+}
+
+async function sendMessage(e) {
+  e.preventDefault();
+  const input = document.getElementById('message-input');
+  const text = input.value.trim();
+  if (!text || !currentConversation) return;
+  await currentConversation.sendMessage(text);
+  input.value = '';
+}
+
+document.getElementById('message-form').addEventListener('submit', sendMessage);
+
+document.getElementById('toggle-assistant').addEventListener('click', async () => {
+  if (!currentConversation) return;
+  const btn = document.getElementById('toggle-assistant');
+  const disabled = btn.dataset.disabled === 'true';
+  const form = new URLSearchParams();
+  form.append('ConversationSid', currentConversation.sid);
+  form.append('ChatServiceSid', currentConversation.serviceSid);
+  form.append('disabled', (!disabled).toString());
+  await fetch('/channels/conversations/toggleAssistant', { method: 'POST', body: form });
+  updateToggleButton(!disabled);
+});
+
+function updateToggleButton(disabled) {
+  const btn = document.getElementById('toggle-assistant');
+  btn.dataset.disabled = disabled;
+  btn.textContent = disabled ? 'Enable AI' : 'Disable AI';
+}
+
+(async function init() {
+  const identity = prompt('Enter your agent identity');
+  const token = await getToken(identity);
+  client = await Twilio.Conversations.Client.create(token);
+  loadConversations();
+})();

--- a/assets/imessage/index.html
+++ b/assets/imessage/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Twilio AI Conversations</title>
+  <link rel="stylesheet" href="styles.css">
+  <script src="https://media.twiliocdn.com/sdk/js/conversations/releases/2.4.0/twilio-conversations.min.js"></script>
+</head>
+<body>
+  <div id="app">
+    <aside id="threads">
+      <h2>Conversations</h2>
+      <ul id="thread-list"></ul>
+    </aside>
+    <section id="messages" class="hidden">
+      <header>
+        <h3 id="contact"></h3>
+        <button id="toggle-assistant" data-disabled="false">Disable AI</button>
+      </header>
+      <div id="message-list"></div>
+      <div id="typing" class="typing hidden">Assistant is typing...</div>
+      <form id="message-form">
+        <input type="text" id="message-input" placeholder="Type a message" autocomplete="off" />
+        <button type="submit">Send</button>
+      </form>
+    </section>
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/assets/imessage/styles.css
+++ b/assets/imessage/styles.css
@@ -1,0 +1,21 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  height: 100vh;
+  display: flex;
+}
+#app { display:flex; width:100%; }
+#threads { width:30%; border-right:1px solid #ddd; overflow-y:auto; }
+#threads ul { list-style:none; padding:0; margin:0; }
+#threads li { padding:10px; border-bottom:1px solid #eee; cursor:pointer; }
+#threads li.active { background-color:#f0f0f0; }
+#messages { flex:1; display:flex; flex-direction:column; }
+.hidden { display:none; }
+#message-list { flex:1; overflow-y:auto; padding:10px; background:#f5f5f7; }
+.message { display:flex; margin-bottom:10px; }
+.message.incoming .bubble { background:#e5e5ea; color:black; margin-right:auto; }
+.message.outgoing .bubble { background:#0b93f6; color:white; margin-left:auto; }
+.bubble { padding:8px 12px; border-radius:20px; max-width:70%; }
+.typing { font-style:italic; margin:5px 10px; color:gray; }
+#message-form { display:flex; border-top:1px solid #ccc; padding:10px; }
+#message-input { flex:1; padding:8px; border-radius:20px; border:1px solid #ccc; }

--- a/functions/channels/conversations/flex-webchat.protected.js
+++ b/functions/channels/conversations/flex-webchat.protected.js
@@ -84,6 +84,11 @@ exports.handler = async function (context, event, callback) {
     ChatServiceSid,
     ConversationSid
   );
+
+  if (attributes.assistantDisabled) {
+    return callback(null, "assistant disabled");
+  }
+
   await client.conversations.v1
     .services(ChatServiceSid)
     .conversations(ConversationSid)

--- a/functions/channels/conversations/messageAdded.protected.js
+++ b/functions/channels/conversations/messageAdded.protected.js
@@ -70,6 +70,11 @@ exports.handler = async function (context, event, callback) {
     ChatServiceSid,
     ConversationSid
   );
+
+  if (attributes.assistantDisabled) {
+    return callback(null, "assistant disabled");
+  }
+
   await client.conversations.v1
     .services(ChatServiceSid)
     .conversations(ConversationSid)

--- a/functions/channels/conversations/toggleAssistant.protected.js
+++ b/functions/channels/conversations/toggleAssistant.protected.js
@@ -1,0 +1,19 @@
+exports.handler = async function(context, event, callback) {
+  const client = context.getTwilioClient();
+  const { ChatServiceSid, ConversationSid, disabled } = event;
+  if (!ChatServiceSid || !ConversationSid) {
+    return callback(new Error('Missing conversation information'));
+  }
+  const attributes = await client.conversations.v1
+    .services(ChatServiceSid)
+    .conversations(ConversationSid)
+    .fetch()
+    .then(conv => conv.attributes ? JSON.parse(conv.attributes) : {})
+    .catch(() => ({}));
+  const updated = { ...attributes, assistantDisabled: disabled === 'true' };
+  await client.conversations.v1
+    .services(ChatServiceSid)
+    .conversations(ConversationSid)
+    .update({ attributes: JSON.stringify(updated) });
+  callback(null, { assistantDisabled: updated.assistantDisabled });
+};

--- a/functions/channels/conversations/token.protected.js
+++ b/functions/channels/conversations/token.protected.js
@@ -1,0 +1,24 @@
+const twilio = require('twilio');
+
+exports.handler = function(context, event, callback) {
+  try {
+    const AccessToken = twilio.jwt.AccessToken;
+    const ChatGrant = AccessToken.ChatGrant;
+
+    const identity = event.identity || 'agent';
+    const token = new AccessToken(
+      context.TWILIO_ACCOUNT_SID,
+      context.TWILIO_API_KEY,
+      context.TWILIO_API_SECRET,
+      { identity }
+    );
+
+    token.addGrant(
+      new ChatGrant({ serviceSid: context.CONVERSATIONS_SERVICE_SID })
+    );
+
+    callback(null, { token: token.toJwt() });
+  } catch (err) {
+    callback(err);
+  }
+};


### PR DESCRIPTION
## Summary
- build new monitoring UI under `/imessage` asset
- add function for Conversations access token
- add function to toggle assistant on/off
- support disabling assistant in conversation handlers
- document new interface and env config

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_683fc308d6c48329ae94e8de58f2e381